### PR TITLE
Fix for slow performance icepay_transactions table with high record count

### DIFF
--- a/app/code/community/Icepay/IceCore/etc/config.xml
+++ b/app/code/community/Icepay/IceCore/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Icepay_IceCore>
-            <version>1.2.9</version>
+            <version>1.2.10</version>
         </Icepay_IceCore>
     </modules>
     <frontend>

--- a/app/code/community/Icepay/IceCore/sql/icepaycore_setup/mysql4-upgrade-1.0.1-1.2.10.php
+++ b/app/code/community/Icepay/IceCore/sql/icepaycore_setup/mysql4-upgrade-1.0.1-1.2.10.php
@@ -1,0 +1,8 @@
+<?php
+
+$installer = $this;
+$installer->startSetup();
+
+$installer->run("CREATE INDEX icepay_trans_order_id ON {$this->getTable('icepay_transactions')} (order_id);");
+
+$installer->endSetup();


### PR DESCRIPTION
To solve the query performance I've added an index on icepay_transactions table column order_id. 
At GroupDeal we had such a high number of transactions the select query took around 8 seconds to find the record. 
This behavior is caused by the use of a compound primary key with a where on only a part of the key.