### PR TITLE
Use Secure url at place payment

### DIFF
--- a/app/code/community/Icepay/IceAdvanced/Model/Checkout/Standard.php
+++ b/app/code/community/Icepay/IceAdvanced/Model/Checkout/Standard.php
@@ -190,7 +190,7 @@ class Icepay_IceAdvanced_Model_Checkout_Standard extends Mage_Payment_Model_Meth
 
     public function getOrderPlaceRedirectUrl()
     {
-        return Mage::getUrl('iceadvanced/processing/pay');
+        return Mage::getUrl('iceadvanced/processing/pay', array('_secure' => true));
     }
 
     public function setCode($str)

--- a/app/code/community/Icepay/IceAdvanced/etc/config.xml
+++ b/app/code/community/Icepay/IceAdvanced/etc/config.xml
@@ -52,7 +52,7 @@
             </custom_quote_process>
         </events>
     </frontend>
-    
+
     <global>
         <models>
             <iceadvanced>
@@ -130,6 +130,10 @@
                 </observers>
             </sales_order_payment_place_end>
         </events>
+
+        <secure_url>
+            <icepayadvanced_processing_pay>/icepayadvanced/processing/pay</icepayadvanced_processing_pay>
+        </secure_url>
     </global>
 
     <adminhtml>
@@ -163,7 +167,7 @@
             </resources>
         </acl>
     </adminhtml>
-    
+
     <admin>
         <routers>
             <iceadvanced>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name"             : "icepay/iceadvanced",
+    "description"      : "IcePay advanced payment module",
+    "type"             : "magento-module",
+    "license"          : "proprietary",
+    "authors"          : [
+        {
+            "name" : "IcePay",
+            "email": "info@icepay.com"
+        }
+    ],
+    "require"          : {
+        "magento-hackathon/magento-composer-installer" : "*"
+    }
+}

--- a/modman
+++ b/modman
@@ -1,0 +1,14 @@
+app/code/community/Icepay/* app/code/community/Icepay/
+app/code/design/adminhtml/default/default/layout/* app/code/design/adminhtml/default/default/layout/
+app/code/design/adminhtml/default/default/template/* app/code/design/adminhtml/default/default/template/
+app/code/design/frontend/base/default/layout/* app/code/design/frontend/base/default/layout/
+app/code/design/frontend/base/default/template/* app/code/design/frontend/base/default/template/
+app/etc/modules/* app/etc/modules/
+app/locale/de_DE/* app/locale/de_DE/
+app/locale/en_US/* app/locale/en_US/
+app/locale/es_ES/* app/locale/es_ES/
+app/locale/fr_FR/* app/locale/fr_FR/
+app/locale/it_IT/* app/locale/it_IT/
+app/locale/nl_NL/* app/locale/nl_NL/
+skin/adminhtml/default/default/icepay skin/adminhtml/default/default/icepay
+skin/frontend/base/default/icepay skin/frontend/base/default/icepay


### PR DESCRIPTION
With the use of a multistore installation this module can give improper redirections if the secure_url isn't used. This will ensure the use of a secure url with the place payment.
Also this will give us a more secure connection with the icepay services.

If we didn't added this fix. the subdomains (non-main store) are giving errors like: `ERR_0007: Checksum for 'CheckoutRequest' is invalid"`

__edit: translated to english__
__edit2: sorry for adding 2 commits, not that used to github and its PR's__