### PR TITLE
On the place_order event use the object from the observer instead of the session object (API-Error)

### DIFF
--- a/app/code/community/Icepay/IceAdvanced/Model/Observer.php
+++ b/app/code/community/Icepay/IceAdvanced/Model/Observer.php
@@ -67,8 +67,12 @@ class Icepay_IceAdvanced_Model_Observer extends Mage_Payment_Block_Form_Containe
      */
     public function sales_order_place_before(Varien_Event_Observer $observer)
     {
-        $quote = Mage::getSingleton('checkout/session')->getQuote();
-        
+        $quote = $observer->getEvent()->getOrder()->getQuote();
+
+        if (!$quote->getId()) {
+            $quote = Mage::getSingleton('checkout/session')->getQuote();
+        }
+
         $paymentMethodCode = $quote->getPayment()->getMethodInstance()->getCode();
         $paymentMethodTitle = $quote->getPayment()->getMethodInstance()->getTitle();
 


### PR DESCRIPTION
When placing an order from with the Magento API, it wont fill the checkout/session object. So this PR will enforce the use of the default observer object, instead of the checkout/session object.
Otherwise its impossible to place an order with the API if this module is installed.

__edit: translated to english__